### PR TITLE
Update Travis dependency manifest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,7 @@ language: node_js
 node_js:
   - "node"
 addons:
-  apt:
-    packages:
-      - google-chrome-stable
-
+  chrome: stable
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start &


### PR DESCRIPTION
Chrome dependency on Travis has been broken: https://travis-ci.community/t/packages-cannot-be-authenticated-google-chrome-stable-dpkg/6852/3