### PR TITLE
Fixes twitter data-title issue

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "Likely",
-  "version": "2.5",
+  "version": "2.5.1",
   "homepage": "http://ilyabirman.ru/projects/likely",
   "authors": [
     "Ilya Birman <ilyabirman@ilyabirman.ru>",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ilyabirman-likely",
   "description": "The social sharing buttons that aren’t shabby",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/ilyabirman/Likely.git"

--- a/source/services/twitter.js
+++ b/source/services/twitter.js
@@ -3,7 +3,7 @@
  */
 
 export default {
-    popupUrl: 'https://twitter.com/intent/tweet?url={url}&text={title}',
+    popupUrl: 'https://twitter.com/intent/tweet?url={url}',
     popupWidth: 600,
     popupHeight: 450,
     click() {


### PR DESCRIPTION
Fixes #188

`title` is being added to the URL if presents (as `&title={title}`), and Twitter understands `title` parameter.
So, we don't need it once again in the URL's template (as `&text={title}`).