### PR TITLE
Support applying `.likely-light` styling conditionally for dark theme users

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ In version 3.0 the following is going to be changed:
 1. Classes `likely-visible` and `likely-ready` will be merged into just `likely-ready`, so please don't rely on `likely-visible` to test the presence.
 2. Unrecognized params passed to the services will be ignored.
 3. Old initialization method will be removed.
-4. Likely buttons will be changed from <div> to <button> tag.
+4. Likely buttons will be changed from `<div>` to `<button>` tag.
 
 As of now, there are deprecation warnings implemented for all the above.
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Version [2.6](https://github.com/NikolayRys/Likely/releases/tag/v2.6) is out �
 See Likely in action on its [homepage](http://ilyabirman.net/projects/likely/).
 
 [![Likely screenshot](http://i.imgur.com/ipqE5Tu.png)](http://ilyabirman.net/projects/likely/)
+[More on choosing a theme](#light--dark-theme)
 
 Likely supports following social networks and messengers:
 
@@ -126,7 +127,7 @@ Top-level options are passed down to all the services. They can also be overridd
 * `data-title` – Text that will be added to the shared URL. Defaults to the page title.
 ```html
 <div class="likely" data-url="https://github.com/ilyabirman/Likely" data-title="My page">
-    <!-- list of serivces -->
+    <!-- List of services -->
 </div>
 ```
 
@@ -284,6 +285,15 @@ Let's assume that you have a 16x16 pixels image and a link to the service which 
     </a>
 </div>
 ```
+
+### Light / dark theme
+It's possible to use alternative (dark-mode suitable) styling by adding `likely-light` class to the main `div.likely`
+```html
+<div class="likely likely-light">
+    <!-- List of services -->
+</div>
+```
+Additionally, if your website is responsive to users' color theme preferences, having `.likely-color-theme-based` instead of `.likely-light` will result in having regular styling for light-mode users and `.likely-light` styling for dark-mode users.
 
 ### Supported browsers
 We support IE 10+, Safari 9+ and the latest versions of Chrome, Firefox and Edge. Likely might work in the older versions too but we don’t maintain the compatibility on purpose.

--- a/README.md
+++ b/README.md
@@ -287,13 +287,13 @@ Let's assume that you have a 16x16 pixels image and a link to the service which 
 ```
 
 ### Light / dark theme
-It's possible to use alternative (dark-mode suitable) styling by adding `likely-light` class to the main `div.likely`
+It's possible to use alternative (dark-mode suitable) styling by adding `likely-dark-theme` (or its old alias `likely-light`) class to the main `div.likely`
 ```html
-<div class="likely likely-light">
+<div class="likely likely-dark-theme">
     <!-- List of services -->
 </div>
 ```
-Additionally, if your website is responsive to users' color theme preferences, having `.likely-color-theme-based` instead of `.likely-light` will result in having regular styling for light-mode users and `.likely-light` styling for dark-mode users.
+Additionally, if your website is responsive to users' color theme preferences, having `.likely-color-theme-based` will result in conditional switch between the themes.
 
 ### Supported browsers
 We support IE 10+, Safari 9+ and the latest versions of Chrome, Firefox and Edge. Likely might work in the older versions too but we don’t maintain the compatibility on purpose.

--- a/source/index.styl
+++ b/source/index.styl
@@ -148,7 +148,7 @@ likely-light-button(button, color) {
     background-image: linear-gradient(to right, rgba(0,0,0,.2) 0, rgba(0,0,0,0) .5px, rgba(0,0,0,0) 100%)
   }
 }
-.likely-light {
+.likely-light, .likely-dark-theme {
   .likely__widget {
     likely-light-widget()
   }
@@ -179,7 +179,7 @@ colorize(button, color) {
       }
     }
   }
-  .likely-light {
+  .likely-light, .likely-dark-theme {
     likely-light-button(button, color)
   }
   @media (prefers-color-scheme: dark) {

--- a/source/index.styl
+++ b/source/index.styl
@@ -111,6 +111,32 @@ likely-background = rgba(231,231,231,.8);
 likely-light-background = rgba(236,236,236,.16);
 likely-light-box-shadow = rgba(0,0,0,.2) 0 0 .33em;
 
+/* Mixins */
+likely-light-widget() {
+  color: #fff;
+  fill: #fff;
+  background: likely-light-background;
+  text-shadow: likely-light-box-shadow;
+}
+
+likely-light-counter() {
+  background-image: linear-gradient(to right, rgba(255,255,255,.4) 0, rgba(255,255,255,0) .5px, rgba(255,255,255,0) 100%)
+}
+
+likely-light-button(button, color) {
+  .likely__widget_{button} {
+    &:hover, &:active, &:focus {
+      text-shadow: color 0 0 .25em;
+      background: alpha(color, 0.7);
+
+      @media (hover: none) {
+        text-shadow: likely-light-box-shadow;
+        background: likely-light-background;
+      }
+    }
+  }
+}
+
 .likely {
   .likely__widget {
     color: #000;
@@ -124,13 +150,21 @@ likely-light-box-shadow = rgba(0,0,0,.2) 0 0 .33em;
 }
 .likely-light {
   .likely__widget {
-    color: #fff;
-    fill: #fff;
-    background: likely-light-background;
-    text-shadow: likely-light-box-shadow;
+    likely-light-widget()
   }
   .likely__counter {
-    background-image: linear-gradient(to right, rgba(255,255,255,.4) 0, rgba(255,255,255,0) .5px, rgba(255,255,255,0) 100%)
+    likely-light-counter()
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .likely-color-theme-based {
+    .likely__widget {
+      likely-light-widget()
+    }
+    .likely__counter {
+      likely-light-counter()
+    }
   }
 }
 
@@ -146,16 +180,11 @@ colorize(button, color) {
     }
   }
   .likely-light {
-    .likely__widget_{button} {
-      &:hover, &:active, &:focus {
-        text-shadow: color 0 0 .25em;
-        background: alpha(color,0.7);
-
-        @media (hover: none) {
-          text-shadow: likely-light-box-shadow;
-          background: likely-light-background;
-        }
-      }
+    likely-light-button(button, color)
+  }
+  @media (prefers-color-scheme: dark) {
+    .likely-color-theme-based {
+      likely-light-button(button, color)
     }
   }
 }

--- a/test/files/manual.html
+++ b/test/files/manual.html
@@ -39,7 +39,7 @@
     </div>
 </div>
 <div style="margin-top: 10px; background-color: #383838">
-    <div class="likely likely-light" data-url="https://google.com/" data-title="ABCD">
+    <div class="likely likely-dark-theme" data-url="https://google.com/" data-title="ABCD">
         <div class="facebook" data-quote="BANANA" data-hashtag="#hello">Share</div>
         <div class="linkedin">Share</div>
         <div class="odnoklassniki" data-imageurl="http://i.imgur.com/zunNbfY.jpg">Like</div>

--- a/test/files/manual.html
+++ b/test/files/manual.html
@@ -11,12 +11,53 @@
             padding: 0;
             margin: 0;
         }
+        @media (prefers-color-scheme: dark) {
+            .theme-based {
+                background-color: #383838;
+            }
+        }
     </style>
 </head>
 
 <body>
 <div>
     <div class="likely" data-url="https://google.com/" data-title="ABCD">
+        <div class="facebook" data-quote="BANANA" data-hashtag="#hello">Share</div>
+        <div class="linkedin">Share</div>
+        <div class="odnoklassniki" data-imageurl="http://i.imgur.com/zunNbfY.jpg">Like</div>
+        <div class="pinterest" data-counter="15" data-media="http://i.imgur.com/zunNbfY.jpg">Pin</div>
+        <div class="reddit">Submit</div>
+        <div class="telegram" data-counter="5">Send</div>
+        <div class="twitter" data-title="ABC" data-hashtags="hello,cats" data-related="@ilyabirman">Tweet</div>
+        <div class="viber" data-title="">Send</div>
+        <div class="vkontakte" data-comment="test">Share</div>
+        <div class="whatsapp" data-hashtag="ptaag" data-unsup="hello">Send</div>
+        <div class="likely__widget">
+            <a class="likely__button" style="color:black" href="https://connect.ok.ru/dk?st.cmd=WidgetSharePreview&st.title=ABCD&st.imageUrl=http%3A%2F%2Fi.imgur.com%2FzunNbfY.jpg&st.shareUrl=https%3A%2F%2Fgoogle.com%2F"><img class="likely__icon" alt="" src="http://postila.ru/images/buttons/16x16.png"> Post
+            </a>
+        </div>
+    </div>
+</div>
+<div style="margin-top: 10px; background-color: #383838">
+    <div class="likely likely-light" data-url="https://google.com/" data-title="ABCD">
+        <div class="facebook" data-quote="BANANA" data-hashtag="#hello">Share</div>
+        <div class="linkedin">Share</div>
+        <div class="odnoklassniki" data-imageurl="http://i.imgur.com/zunNbfY.jpg">Like</div>
+        <div class="pinterest" data-counter="15" data-media="http://i.imgur.com/zunNbfY.jpg">Pin</div>
+        <div class="reddit">Submit</div>
+        <div class="telegram" data-counter="5">Send</div>
+        <div class="twitter" data-title="ABC" data-hashtags="hello,cats" data-related="@ilyabirman">Tweet</div>
+        <div class="viber" data-title="">Send</div>
+        <div class="vkontakte" data-comment="test">Share</div>
+        <div class="whatsapp" data-hashtag="ptaag" data-unsup="hello">Send</div>
+        <div class="likely__widget">
+            <a class="likely__button" style="color:black" href="https://connect.ok.ru/dk?st.cmd=WidgetSharePreview&st.title=ABCD&st.imageUrl=http%3A%2F%2Fi.imgur.com%2FzunNbfY.jpg&st.shareUrl=https%3A%2F%2Fgoogle.com%2F"><img class="likely__icon" alt="" src="http://postila.ru/images/buttons/16x16.png"> Post
+            </a>
+        </div>
+    </div>
+</div>
+<div class="theme-based" style="margin-top: 10px;">
+    <div class="likely likely-color-theme-based" data-url="https://google.com/" data-title="ABCD">
         <div class="facebook" data-quote="BANANA" data-hashtag="#hello">Share</div>
         <div class="linkedin">Share</div>
         <div class="odnoklassniki" data-imageurl="http://i.imgur.com/zunNbfY.jpg">Like</div>


### PR DESCRIPTION
This way developers that support different page styling based on their end users' light / dark theme preferences can also make use of both our regular & dark themes. Applying `.likely-light` unconditionally works as before.

`Readme` is updated accordingly, including the missing information about the already existing `likely-light` theme (was reflected in the screenshots, but not in the description).

Additionally, the `manual` testing file is extended with rows having hardcoded / conditional dark theme (doubting about this one, done in a separate easily revertable commit).