### PR TITLE
Text color fix for custom buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Let's assume that you have a 16x16 pixels image and a link to the service which 
 ```html
 <div class="likely__widget">
     <!-- List of other services -->
-    <a class="likely__button" style="color:black" href="https://new.service.share.url">
+    <a class="likely__button" href="https://new.service.share.url">
         <img class="likely__icon" alt="" src="https://url.of/the/image/16x16.png">
         Post
     </a>

--- a/source/index.styl
+++ b/source/index.styl
@@ -46,6 +46,7 @@
     position: relative;
     cursor: pointer;
     user-select: none;
+    color: inherit;
   }
 
   &__counter {

--- a/test/files/manual.html
+++ b/test/files/manual.html
@@ -33,7 +33,7 @@
         <div class="vkontakte" data-comment="test">Share</div>
         <div class="whatsapp" data-hashtag="ptaag" data-unsup="hello">Send</div>
         <div class="likely__widget">
-            <a class="likely__button" style="color:black" href="https://connect.ok.ru/dk?st.cmd=WidgetSharePreview&st.title=ABCD&st.imageUrl=http%3A%2F%2Fi.imgur.com%2FzunNbfY.jpg&st.shareUrl=https%3A%2F%2Fgoogle.com%2F"><img class="likely__icon" alt="" src="http://postila.ru/images/buttons/16x16.png"> Post
+            <a class="likely__button" href="https://connect.ok.ru/dk?st.cmd=WidgetSharePreview&st.title=ABCD&st.imageUrl=http%3A%2F%2Fi.imgur.com%2FzunNbfY.jpg&st.shareUrl=https%3A%2F%2Fgoogle.com%2F"><img class="likely__icon" alt="" src="http://postila.ru/images/buttons/16x16.png"> Post
             </a>
         </div>
     </div>
@@ -51,7 +51,7 @@
         <div class="vkontakte" data-comment="test">Share</div>
         <div class="whatsapp" data-hashtag="ptaag" data-unsup="hello">Send</div>
         <div class="likely__widget">
-            <a class="likely__button" style="color:black" href="https://connect.ok.ru/dk?st.cmd=WidgetSharePreview&st.title=ABCD&st.imageUrl=http%3A%2F%2Fi.imgur.com%2FzunNbfY.jpg&st.shareUrl=https%3A%2F%2Fgoogle.com%2F"><img class="likely__icon" alt="" src="http://postila.ru/images/buttons/16x16.png"> Post
+            <a class="likely__button" href="https://connect.ok.ru/dk?st.cmd=WidgetSharePreview&st.title=ABCD&st.imageUrl=http%3A%2F%2Fi.imgur.com%2FzunNbfY.jpg&st.shareUrl=https%3A%2F%2Fgoogle.com%2F"><img class="likely__icon" alt="" src="http://postila.ru/images/buttons/16x16.png"> Post
             </a>
         </div>
     </div>
@@ -69,7 +69,7 @@
         <div class="vkontakte" data-comment="test">Share</div>
         <div class="whatsapp" data-hashtag="ptaag" data-unsup="hello">Send</div>
         <div class="likely__widget">
-            <a class="likely__button" style="color:black" href="https://connect.ok.ru/dk?st.cmd=WidgetSharePreview&st.title=ABCD&st.imageUrl=http%3A%2F%2Fi.imgur.com%2FzunNbfY.jpg&st.shareUrl=https%3A%2F%2Fgoogle.com%2F"><img class="likely__icon" alt="" src="http://postila.ru/images/buttons/16x16.png"> Post
+            <a class="likely__button" href="https://connect.ok.ru/dk?st.cmd=WidgetSharePreview&st.title=ABCD&st.imageUrl=http%3A%2F%2Fi.imgur.com%2FzunNbfY.jpg&st.shareUrl=https%3A%2F%2Fgoogle.com%2F"><img class="likely__icon" alt="" src="http://postila.ru/images/buttons/16x16.png"> Post
             </a>
         </div>
     </div>


### PR DESCRIPTION
See https://github.com/NikolayRys/Likely/commit/0cd57ba5513564f5863fa0e2e6294b7a77127d79

Improves the situation for custom buttons which had to have inline styling in order not to get the default `a`-tag blue.  Standard buttons work as before.

Mostly important for `.likely-color-theme-based` styling. Additionally, we can get rid of our suggestion to use inline styling, which is always nice.

<img width="790" alt="Screenshot_2022-01-30_at_19_10_53" src="https://user-images.githubusercontent.com/17530843/151709692-5b0d9169-a7e3-4db4-ac63-368b3568273f.png">

