### PR TITLE
Styling fix for media `hover: none`

### DIFF
--- a/source/index.styl
+++ b/source/index.styl
@@ -129,11 +129,15 @@ likely-light-button(button, color) {
     &:hover, &:active, &:focus {
       text-shadow: color 0 0 .25em;
       background: alpha(color, 0.7);
+    }
+  }
+}
 
-      @media (hover: none) {
-        text-shadow: likely-light-box-shadow;
-        background: likely-light-background;
-      }
+likely-light-media-none-button(button, color) {
+  .likely__widget_{button} {
+    &:hover, &:active, &:focus {
+      text-shadow: likely-light-box-shadow;
+      background: likely-light-background;
     }
   }
 }
@@ -182,10 +186,19 @@ colorize(button, color) {
   }
   .likely-light, .likely-dark-theme {
     likely-light-button(button, color)
+
+    @media (hover: none) {
+      likely-light-media-none-button(button, color)
+    }
   }
   @media (prefers-color-scheme: dark) {
     .likely-color-theme-based {
       likely-light-button(button, color)
+    }
+  }
+  @media (prefers-color-scheme: dark) and (hover: none) {
+    .likely-color-theme-based {
+      likely-light-media-none-button(button, color)
     }
   }
 }


### PR DESCRIPTION
Without digging too much, it seems like the problem is caused by having one `media` query (`likely-light-button` function) inside another (when we call it inside `@media (prefers-color-scheme: dark)`) -- and oh no, we're losing our scope, having this in the resulting CSS:
<img width="653" alt="Screenshot 2022-09-25 at 16 25 01" src="https://user-images.githubusercontent.com/17530843/192147256-b598d052-c06b-4fb6-8dc1-63b4a0897834.png">

This PR achieves removing this block so that our theme-based CSS looks like this:
<img width="769" alt="Screenshot 2022-09-25 at 16 49 54" src="https://user-images.githubusercontent.com/17530843/192147300-2ed1264b-3e5e-432f-9ca9-5bf76b5bfbd8.png">
which corresponds to our hardcoded dark theme (unchanged compared to `master`):
<img width="1025" alt="Screenshot 2022-09-25 at 16 49 47" src="https://user-images.githubusercontent.com/17530843/192147358-0af02872-d880-4c49-8a93-58b3b7282611.png">

@NikolayRys could you verify? There also might be a more elegant solution, but this separation was the first thing that came to my mind and it seems to do the trick.